### PR TITLE
Added empty tag components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ add_library(ginseng INTERFACE)
 set_property(TARGET ginseng PROPERTY INTERFACE_SOURCES ${ginseng_SOURCES})
 target_include_directories(ginseng INTERFACE include)
 
-add_executable(test_ginseng EXCLUDE_FROM_ALL src/main.cpp src/test.cpp src/catch.hpp src/test_emplacement.cpp)
+add_executable(test_ginseng EXCLUDE_FROM_ALL src/main.cpp src/test.cpp src/catch.hpp src/test_emplacement.cpp src/test_tags.cpp)
 set_property(TARGET test_ginseng PROPERTY CXX_STANDARD 14)
 target_link_libraries(test_ginseng ginseng)

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -175,3 +175,22 @@ TEST_CASE("Databases can visit entities with specific components", "[ginseng]")
     REQUIRE(num_visited == 0);
 }
 
+TEST_CASE("ComInfo can be used instead of components", "[ginseng]")
+{
+    DB db;
+
+    struct Data {};
+
+    auto ent = db.makeEntity();
+    auto info = db.makeComponent(ent,Data{});
+
+    int visited = 0;
+    DB::ComInfo<Data> info2;
+    db.visit([&](DB::ComInfo<Data>& data){
+        ++visited;
+        info2 = data;
+    });
+    REQUIRE(visited == 1);
+    REQUIRE(info2.id() == info.id());
+}
+

--- a/src/test_tags.cpp
+++ b/src/test_tags.cpp
@@ -1,0 +1,41 @@
+#include "catch.hpp"
+
+#include <ginseng/ginseng.hpp>
+
+using DB = Ginseng::Database<>;
+using Ginseng::Not;
+using Ginseng::Tag;
+using EntID = DB::EntID;
+using ComID = DB::ComID;
+
+TEST_CASE("Tag types do not use dynamic allocation", "[ginseng]")
+{
+    // Not sure how to actually test this, since allocations happen for the list nodes and entity vector.
+    // Instead, I'll just check to make sure it actually compiles.
+
+    DB db;
+
+    struct SomeTag {};
+
+    auto ent = db.makeEntity();
+    DB::ComInfo<Tag<SomeTag>> tag_info = db.makeComponent(ent, Tag<SomeTag>{});
+
+    int visited;
+    DB::ComInfo<Tag<SomeTag>> visited_info;
+
+    visited = 0;
+    db.visit([&](Tag<SomeTag>){
+        ++visited;
+    });
+
+    REQUIRE(visited == 1);
+
+    visited = 0;
+    db.visit([&](DB::ComInfo<Tag<SomeTag>> info){
+        ++visited;
+        visited_info = info;
+    });
+
+    REQUIRE(visited == 1);
+    REQUIRE(visited_info.id() == tag_info.id());
+}


### PR DESCRIPTION
Resolves #1 by adding `Tag<T>` component types that ensure no dynamically allocated component will be created. When retrieved from an entity, the tag component will have no value.